### PR TITLE
Restricted certain URLs to specific roles

### DIFF
--- a/src/main/java/com/cpan252/clotheswarehouse/config/SecurityConfig.java
+++ b/src/main/java/com/cpan252/clotheswarehouse/config/SecurityConfig.java
@@ -39,13 +39,20 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests()
                 .requestMatchers(toH2Console()).permitAll()
-                .requestMatchers( "/add","/clothlist")
+                //Only allows Users withe the role ADMIN to acess these pages urls
+                .requestMatchers("")
+                .hasRole("ADMIN")
+                //Only allows Users with the role EMPLOYEE to access these pages urls
+                .requestMatchers( "/add")
+                .hasRole("EMPLOYEE")
+                //Allows people with the role USER to these pages urls
+                .requestMatchers("/clothlist")
                 .hasRole("USER")
                 .anyRequest().permitAll()
                 .and()
                 .formLogin()
                 .loginPage("/login")
-                .defaultSuccessUrl("/add", true)
+                .defaultSuccessUrl("/clothlist", true)
                 .and()
                 .logout()
                 .logoutSuccessUrl("/")

--- a/src/main/java/com/cpan252/clotheswarehouse/model/User.java
+++ b/src/main/java/com/cpan252/clotheswarehouse/model/User.java
@@ -33,7 +33,9 @@ public class User implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         if (username.equals("admin"))
-            return List.of(new SimpleGrantedAuthority("ROLE_USER"), new SimpleGrantedAuthority("ROLE_ADMIN"));
+            return List.of(new SimpleGrantedAuthority("ROLE_USER"), new SimpleGrantedAuthority("ROLE_EMPLOYEE"), new SimpleGrantedAuthority("ROLE_ADMIN"));
+        if(username.contains("empl"))
+            return List.of(new SimpleGrantedAuthority("ROLE_USER"), new SimpleGrantedAuthority("ROLE_EMPLOYEE"));
         return List.of(new SimpleGrantedAuthority("ROLE_USER"));
     }
 


### PR DESCRIPTION
I have added the Employee role, as well as restricted the /add to employees only, as well as added a template for admin only roles